### PR TITLE
meta, links, included フィールドがnilの場合はフィールドを追加しない

### DIFF
--- a/lib/grape_jsonapi-serializer/formatter.rb
+++ b/lib/grape_jsonapi-serializer/formatter.rb
@@ -49,7 +49,13 @@ module Grape
               links = serialized[:links]
               included << serialized[:included]
             end
-            { data: data, meta: meta, links: links, included: included.flatten }
+            included = included.flatten&.compact if included.present?
+
+            ret = { data: data }
+            ret.merge!(meta: meta) unless meta.blank?
+            ret.merge!(links: links) unless links.blank?
+            ret.merge!(included: included) unless included.blank?
+            ret
           else
             jsonapi_serializer_serializable(collection, options)&.serializable_hash || collection.map(&:serializable_hash)
           end


### PR DESCRIPTION
`meta`, `links`, `included` の3つのフィールドについて、`nil` もしくは 要素が `nil` の配列の場合、フィールドを追加しないという処理にしました。

`nil` => フィールドなし
`[nil]` => フィールドなし

---

`included` が必ず存在しないといけないのであれば、 下記のように変更する必要があります。

`nil` => フィールドなし
`[nil]` => `[]`